### PR TITLE
Update `socket2` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if",
  "libc",


### PR DESCRIPTION
Update `socket2` crate to non-yanked version 0.3.16 to make the project compile successfully.

More info
- https://github.com/rust-lang/socket2/issues/139
- https://github.com/rust-lang/rust/issues/62875

---

Before

<img width="828" alt="image" src="https://user-images.githubusercontent.com/318504/210627775-269ee1f5-702f-4f0a-b7c3-7db638b34959.png">

---

After

<img width="491" alt="image" src="https://user-images.githubusercontent.com/318504/210627853-45eb1cf7-8032-4ad1-b99b-c55d044707dc.png">
